### PR TITLE
feat: base ShowList infinite pagination on TMDB total_pages

### DIFF
--- a/src/components/ShowList/useQueryShow.tsx
+++ b/src/components/ShowList/useQueryShow.tsx
@@ -15,16 +15,13 @@ export const useQueryShow = ({
   category,
   cardAmount,
 }: IUseQueryShowProps) => {
-  const totalPages = 6;
-
   const infiniteResults = useInfiniteQuery({
     queryKey: ['shows', 'infinite', section, category, id],
     queryFn: ({ pageParam }) =>
       fetchShows({ pageParam, section, category, id }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) =>
-      lastPage.page < totalPages ? lastPage.page + 1 : undefined,
-    maxPages: 6,
+      lastPage.page < lastPage.total_pages ? lastPage.page + 1 : undefined,
     enabled: !cardAmount,
   });
 

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -127,6 +127,8 @@ type Video = {
 type ShowResponse = {
   page: number;
   results: Show[];
+  total_pages: number;
+  total_results?: number;
 };
 
 interface Favorite {


### PR DESCRIPTION
Stop Load more using API total_pages instead of a hardcoded page limit, and drop maxPages so fetched pages stay in the list. Extend ShowResponse typing.